### PR TITLE
feat: schema provider - query facts out of session state, unwrap reducer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,7 @@ module.exports = {
     browser: true,
   },
 
-  extends: ['prettier', 'plugin:import/typescript', 'plugin:react/recommended'],
+  extends: ['prettier', 'plugin:import/typescript', 'plugin:react/recommended', 'plugin:react-hooks/recommended'],
 
   globals: {
     atom: false,

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "eslint-plugin-jest": "^23.1.1",
     "eslint-plugin-prefer-object-spread": "1.2.1",
     "eslint-plugin-react": "7.18.3",
+    "eslint-plugin-react-hooks": "^3.0.0",
     "fetch-mock": "6.5.2",
     "flow-bin": "^0.119.1",
     "graphql": "^14.6.0",

--- a/packages/graphiql/src/components/VariableEditor.tsx
+++ b/packages/graphiql/src/components/VariableEditor.tsx
@@ -12,6 +12,7 @@ import onHasCompletion from '../utility/onHasCompletion';
 import commonKeys from '../utility/commonKeys';
 import { useSessionContext } from '../state/GraphiQLSessionProvider';
 import { useSchemaContext } from '../state/GraphiQLSchemaProvider';
+import useQueryFacts from '../hooks/useQueryFacts';
 
 declare module CodeMirror {
   export interface Editor extends CM.Editor {}
@@ -49,6 +50,7 @@ type VariableEditorProps = {
  */
 export function VariableEditor(props: VariableEditorProps) {
   const session = useSessionContext();
+  const queryFacts = useQueryFacts();
   const { schema } = useSchemaContext();
   const [ignoreChangeEvent, setIgnoreChangeEvent] = React.useState(false);
   const editorRef = React.useRef<(CM.Editor & { options: any }) | null>(null);
@@ -210,11 +212,11 @@ export function VariableEditor(props: VariableEditorProps) {
     if (!editor) {
       return;
     }
-    if (session?.variableToType) {
-      editor.options.lint.variableToType = session.variableToType;
-      editor.options.hintOptions.variableToType = session.variableToType;
+    if (queryFacts?.variableToType) {
+      editor.options.lint.variableToType = queryFacts.variableToType;
+      editor.options.hintOptions.variableToType = queryFacts.variableToType;
     }
-  }, [session.operation.text, schema]);
+  }, [queryFacts]);
 
   return <div className="codemirrorWrap" ref={divRef} />;
 }

--- a/packages/graphiql/src/hooks/useOperation.ts
+++ b/packages/graphiql/src/hooks/useOperation.ts
@@ -1,0 +1,6 @@
+import { useSessionContext } from '../state/GraphiQLSessionProvider';
+
+export default function useOperation() {
+  const { operation } = useSessionContext();
+  return operation;
+}

--- a/packages/graphiql/src/hooks/useQueryFacts.ts
+++ b/packages/graphiql/src/hooks/useQueryFacts.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+
+import getQueryFacts from '../utility/getQueryFacts';
+import useSchema from './useSchema';
+import useOperation from './useOperation';
+
+export default function useQueryFacts() {
+  const schema = useSchema();
+  const { text } = useOperation();
+  return useMemo(() => (schema ? getQueryFacts(schema, text) : null), [
+    schema,
+    text,
+  ]);
+}

--- a/packages/graphiql/src/hooks/useSchema.ts
+++ b/packages/graphiql/src/hooks/useSchema.ts
@@ -1,0 +1,6 @@
+import { useSchemaContext } from '../state/GraphiQLSchemaProvider';
+
+export default function useSchema() {
+  const { schema } = useSchemaContext();
+  return schema;
+}

--- a/packages/graphiql/src/state/GraphiQLSessionProvider.tsx
+++ b/packages/graphiql/src/state/GraphiQLSessionProvider.tsx
@@ -62,7 +62,10 @@ export const SessionContext = React.createContext<
 
 export const useSessionContext = () => React.useContext(SessionContext);
 
-function reducer(state: SessionState, action: SessionAction): SessionState {
+function sessionReducer(
+  state: SessionState,
+  action: SessionAction,
+): SessionState {
   switch (action.type) {
     case SessionActionTypes.OperationRequested:
       return {
@@ -145,7 +148,7 @@ export function SessionProvider({
     SessionActionTypes,
     SessionAction
   >({
-    reducers: [reducer],
+    reducers: [sessionReducer],
     init: () => initialState,
   });
 

--- a/packages/graphiql/src/state/GraphiQLSessionProvider.tsx
+++ b/packages/graphiql/src/state/GraphiQLSessionProvider.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import { useReducers, DispatchWithEffects } from './useReducers';
 import { Fetcher } from './types';
-import getQueryFacts from '../utility/getQueryFacts';
 
 import { GraphQLParams, SessionState, EditorContexts } from './types';
 
 import { defaultFetcher } from './common';
 import { SchemaContext } from './GraphiQLSchemaProvider';
-import { GraphQLSchema } from 'graphql';
 import {
   SessionAction,
   SessionActionTypes,
@@ -18,7 +16,7 @@ import {
   editorLoadedAction,
   operationErroredAction,
 } from './sessionActions';
-import { observableToPromise } from 'src/utility/observableToPromise';
+import { observableToPromise } from '../utility/observableToPromise';
 
 type Dispatcher = DispatchWithEffects<SessionActionTypes, SessionAction>;
 
@@ -62,87 +60,83 @@ export const SessionContext = React.createContext<
   SessionState & SessionHandlers
 >(initialContextState);
 
-export const useSessionContext = (): SessionState & SessionHandlers =>
-  React.useContext(SessionContext);
+export const useSessionContext = () => React.useContext(SessionContext);
 
-export function getSessionReducer(schema: GraphQLSchema) {
-  return (state: SessionState, action: SessionAction): SessionState => {
-    switch (action.type) {
-      case SessionActionTypes.OperationRequested:
-        return {
-          ...state,
-          operationLoading: true,
-        };
-      case SessionActionTypes.EditorLoaded: {
-        const { context, editor } = action.payload;
-        return {
-          ...state,
-          editors: {
-            ...state.editors,
-            [context as EditorContexts]: editor,
-          },
-        };
-      }
-      case SessionActionTypes.OperationChanged: {
-        const { value } = action.payload;
-        return {
-          ...state,
-          operation: {
-            ...state.operation,
-            text: value,
-          },
-          ...getQueryFacts(schema, value),
-        };
-      }
-      case SessionActionTypes.VariablesChanged: {
-        const { value } = action.payload;
-        return {
-          ...state,
-          variables: {
-            ...state.variables,
-            text: value,
-          },
-        };
-      }
-      case SessionActionTypes.OperationSucceeded: {
-        const { result } = action.payload;
-        return {
-          ...state,
-          results: {
-            ...state.results,
-            text: result,
-          },
-          operationErrors: null,
-        };
-      }
-      case SessionActionTypes.OperationErrored: {
-        const { error } = action.payload;
-        return {
-          ...state,
-          operationErrors: state.operationErrors
-            ? [...state.operationErrors, error]
-            : [error],
-        };
-      }
-      default: {
-        return state;
-      }
+function reducer(state: SessionState, action: SessionAction): SessionState {
+  switch (action.type) {
+    case SessionActionTypes.OperationRequested:
+      return {
+        ...state,
+        operationLoading: true,
+      };
+    case SessionActionTypes.EditorLoaded: {
+      const { context, editor } = action.payload;
+      return {
+        ...state,
+        editors: {
+          ...state.editors,
+          [context as EditorContexts]: editor,
+        },
+      };
     }
-  };
+    case SessionActionTypes.OperationChanged: {
+      const { value } = action.payload;
+      return {
+        ...state,
+        operation: {
+          ...state.operation,
+          text: value,
+        },
+      };
+    }
+    case SessionActionTypes.VariablesChanged: {
+      const { value } = action.payload;
+      return {
+        ...state,
+        variables: {
+          ...state.variables,
+          text: value,
+        },
+      };
+    }
+    case SessionActionTypes.OperationSucceeded: {
+      const { result } = action.payload;
+      return {
+        ...state,
+        results: {
+          ...state.results,
+          text: result,
+        },
+        operationErrors: null,
+      };
+    }
+    case SessionActionTypes.OperationErrored: {
+      const { error } = action.payload;
+      return {
+        ...state,
+        operationErrors: state.operationErrors
+          ? [...state.operationErrors, error]
+          : [error],
+      };
+    }
+    default: {
+      return state;
+    }
+  }
 }
 
 export type SessionProviderProps = {
   sessionId: number;
   fetcher?: Fetcher;
   session?: SessionState;
-  children: any;
+  children: React.ReactNode;
 };
 
 export function SessionProvider({
   sessionId,
   fetcher = defaultFetcher,
   session,
-  ...props
+  children,
 }: SessionProviderProps) {
   const schemaState = React.useContext(SchemaContext);
 
@@ -151,43 +145,66 @@ export function SessionProvider({
     SessionActionTypes,
     SessionAction
   >({
-    reducers: [getSessionReducer(schemaState.schema as GraphQLSchema)],
+    reducers: [reducer],
     init: () => initialState,
   });
 
-  const operationError = (error: Error) =>
-    dispatch(operationErroredAction(error, sessionId));
-  const editorLoaded = (context: EditorContexts, editor: CodeMirror.Editor) => {
-    dispatch(editorLoadedAction(context, editor));
-  };
-  const changeOperation = (operationText: string) => {
-    dispatch(operationChangedAction(operationText, sessionId));
-  };
+  const operationError = React.useCallback(
+    (error: Error) => dispatch(operationErroredAction(error, sessionId)),
+    [dispatch, sessionId],
+  );
 
-  const changeVariables = (variablesText: string) =>
-    dispatch(variableChangedAction(variablesText, sessionId));
-  const executeOperation = async (operationName?: string) => {
-    try {
-      dispatch(operationRequestAction());
+  const editorLoaded = React.useCallback(
+    (context: EditorContexts, editor: CodeMirror.Editor) =>
+      dispatch(editorLoadedAction(context, editor)),
+    [dispatch],
+  );
 
-      const fetchValues: GraphQLParams = {
-        query: state.operation?.text ?? '',
-      };
-      if (state.variables?.text) {
-        fetchValues.variables = state.variables.text as string;
+  const changeOperation = React.useCallback(
+    (operationText: string) =>
+      dispatch(operationChangedAction(operationText, sessionId)),
+    [dispatch, sessionId],
+  );
+
+  const changeVariables = React.useCallback(
+    (variablesText: string) =>
+      dispatch(variableChangedAction(variablesText, sessionId)),
+    [dispatch, sessionId],
+  );
+
+  const executeOperation = React.useCallback(
+    async (operationName?: string) => {
+      try {
+        dispatch(operationRequestAction());
+
+        const fetchValues: GraphQLParams = {
+          query: state.operation?.text ?? '',
+        };
+        if (state.variables?.text) {
+          fetchValues.variables = state.variables.text as string;
+        }
+        if (operationName) {
+          fetchValues.operationName = operationName as string;
+        }
+        const result = await observableToPromise(
+          fetcher(fetchValues, schemaState.config),
+        );
+        dispatch(operationSucceededAction(result, sessionId));
+      } catch (err) {
+        console.error(err.name, err.stack);
+        operationError(err);
       }
-      if (operationName) {
-        fetchValues.operationName = operationName as string;
-      }
-      const result = await observableToPromise(
-        fetcher(fetchValues, schemaState.config),
-      );
-      dispatch(operationSucceededAction(result, sessionId));
-    } catch (err) {
-      console.error(err.name, err.stack);
-      operationError(err);
-    }
-  };
+    },
+    [
+      dispatch,
+      fetcher,
+      operationError,
+      schemaState.config,
+      sessionId,
+      state.operation,
+      state.variables,
+    ],
+  );
 
   return (
     <SessionContext.Provider
@@ -201,7 +218,7 @@ export function SessionProvider({
         editorLoaded,
         dispatch,
       }}>
-      {props.children}
+      {children}
     </SessionContext.Provider>
   );
 }

--- a/packages/graphiql/src/state/types.ts
+++ b/packages/graphiql/src/state/types.ts
@@ -70,4 +70,4 @@ export type SessionState = {
   operations: OperationDefinitionNode[];
   subscription?: Unsubscribable | null;
   operationName?: string; // current operation name
-} & QueryFacts;
+};


### PR DESCRIPTION
_This is a PR against https://github.com/graphql/graphiql/pull/1462_

It looks like we can unwrap the `getSessionReducer` that creates a reducer with access to the `schema` via closure, as it's only used to store query facts (derived state!). I made some extra-small hooks to consume operation and schema, and use that in a `getQueryFacts` hook that returns memoized query facts.

I also wrapped the session action handlers in `useCallback`.
